### PR TITLE
Refactor read_own_code path handling

### DIFF
--- a/src/modules/command_executor.py
+++ b/src/modules/command_executor.py
@@ -1,6 +1,5 @@
-import os
 import subprocess
-import shlex
+from modules.file_utils import read_own_code
 
 
 def lazy_import_self_improvement():
@@ -33,18 +32,3 @@ def execute_command(command):
         return result.stdout.strip() or result.stderr.strip()
     except Exception as e:
         return f"Command execution error: {e}"
-
-
-def read_own_code(filepath):
-    """Reads the content of a file from the bot's own directory."""
-    base_dir = os.path.dirname(os.path.abspath(__file__))  # Get current directory
-    target_path = os.path.join(base_dir, filepath)
-
-    if not os.path.exists(target_path):
-        return f"Error: {filepath} not found."
-
-    try:
-        with open(target_path, "r", encoding="utf-8") as f:
-            return f.read()
-    except Exception as e:
-        return f"Error reading file: {e}"

--- a/src/modules/file_utils.py
+++ b/src/modules/file_utils.py
@@ -1,15 +1,27 @@
 import os
 
-def read_own_code(filepath):
-    """Reads the content of a file from the bot's own directory."""
-    base_dir = os.path.dirname(os.path.abspath(__file__))  # Get current directory
-    target_path = os.path.join(base_dir, filepath)
 
-    if not os.path.exists(target_path):
+def read_own_code(filepath):
+    """Reads the content of a file from the project directory.
+
+    The provided path is normalized and validated to ensure it remains within
+    the project root to prevent path traversal attacks.
+    """
+    # Determine the project root (two levels up from this file: src/modules)
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+    # Normalize the requested path relative to the project root
+    normalized_path = os.path.abspath(os.path.join(project_root, filepath))
+
+    # Validate that the normalized path is still within the project directory
+    if not normalized_path.startswith(project_root):
+        return "Error: Invalid file path."
+
+    if not os.path.exists(normalized_path):
         return f"Error: {filepath} not found."
 
     try:
-        with open(target_path, "r", encoding="utf-8") as f:
+        with open(normalized_path, "r", encoding="utf-8") as f:
             return f.read()
     except Exception as e:
         return f"Error reading file: {e}"


### PR DESCRIPTION
## Summary
- remove duplicated `read_own_code` from `command_executor`
- import `read_own_code` from `file_utils`
- enhance `read_own_code` in `file_utils` to normalize and validate paths to avoid path traversal

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68473530f450832ebc85b1f43f089052