### PR TITLE
Fix command parsing to avoid shell=True

### DIFF
--- a/src/modules/command_executor.py
+++ b/src/modules/command_executor.py
@@ -13,7 +13,13 @@ def execute_command(command):
     """Secure command execution using a whitelist approach."""
     allowed_commands = ["ls", "pwd", "whoami", "df", "free", "uptime", "echo", "cat", "self_improve"]
 
-    command_parts = command.split()
+    try:
+        command_parts = shlex.split(command)
+    except ValueError as e:
+        return f"Error parsing command: {e}"
+
+    if not command_parts:
+        return "Error: No command provided."
 
     print(f"[DEBUG] Command received: {command_parts[0]}")  # ✅ Debugging print
     print(f"[DEBUG] Allowed commands: {allowed_commands}")  # ✅ Debugging print
@@ -28,8 +34,12 @@ def execute_command(command):
         self_improve = lazy_import_self_improvement()  # ✅ Import only when needed
         return self_improve.self_improve_code(command_parts[1])
 
+    for arg in command_parts[1:]:
+        if any(symbol in arg for symbol in [';', '&', '|', '$', '>', '<']):
+            return "Error: Invalid characters in arguments."
+
     try:
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        result = subprocess.run(command_parts, shell=False, capture_output=True, text=True)
         return result.stdout.strip() or result.stderr.strip()
     except Exception as e:
         return f"Command execution error: {e}"


### PR DESCRIPTION
## Summary
- secure execute_command by using `shlex.split` and `shell=False`
- validate arguments before execution to prevent shell operators

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847352f11cc832e86d524424d3cc2b4