### PR TITLE
Add threaded port scanner with interactive recon tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can also run the built-in port scanner with:
 ./blizz scan <target>
 ```
 
+After scanning, an interactive menu lets you display common service names or
+basic recon tips for the detected ports. Use this only on systems you have
+explicit permission to test.
+
 The script displays a welcome banner, processes any stored memory, and then enters a chat loop where you can interact with the bot. Type `exit` to leave the chat.
 
 ## Configuration Files

--- a/src/blizz_cli.py
+++ b/src/blizz_cli.py
@@ -2,7 +2,7 @@ import argparse
 from typing import List
 
 from main import main as run_chat
-from modules.port_scanner import scan_target
+from modules.port_scanner import scan_target, interactive_menu
 
 
 def parse_ports(port_str: str) -> List[int]:
@@ -31,6 +31,7 @@ def main() -> None:
             print(f"Open ports on {args.target}: {', '.join(map(str, open_ports))}")
         else:
             print(f"No open ports found on {args.target}")
+        interactive_menu(open_ports)
     else:
         run_chat()
 

--- a/src/modules/port_scanner.py
+++ b/src/modules/port_scanner.py
@@ -1,11 +1,37 @@
 import socket
-from typing import Iterable, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, Iterable, List, Tuple
+
+# Common service names and simple recon tips for educational use
+SERVICE_TIPS: Dict[int, Tuple[str, str]] = {
+    21: ("FTP", "Try anonymous login or inspect the banner for version info."),
+    22: ("SSH", "Check for default credentials or weak key auth if permitted."),
+    80: ("HTTP", "Browse the web interface or use curl to inspect pages."),
+    443: ("HTTPS", "Similar to HTTP but over TLS; inspect certificates."),
+    3306: ("MySQL", "Look for default credentials or test basic queries."),
+}
+
+
+def _scan_single_port(target: str, port: int, timeout: float) -> int | None:
+    """Attempt to connect to a single TCP port.
+
+    Returns the port number if open, otherwise ``None``.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        try:
+            sock.connect((target, port))
+        except (socket.timeout, ConnectionRefusedError, OSError):
+            return None
+        else:
+            return port
 
 
 def scan_target(
-    target: str, ports: Iterable[int] | None = None, timeout: float = 0.5
+    target: str, ports: Iterable[int] | None = None, timeout: float = 0.5,
+    max_workers: int = 100
 ) -> List[int]:
-    """Scan target host for open TCP ports.
+    """Scan target host for open TCP ports using threads.
 
     Args:
         target: Hostname or IP address to scan.
@@ -19,13 +45,48 @@ def scan_target(
         ports = range(1, 1025)
 
     open_ports: List[int] = []
-    for port in ports:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.settimeout(timeout)
-            try:
-                sock.connect((target, port))
-            except (socket.timeout, ConnectionRefusedError, OSError):
-                continue
-            else:
-                open_ports.append(port)
-    return open_ports
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(_scan_single_port, target, p, timeout): p for p in ports}
+        for future in as_completed(futures):
+            result = future.result()
+            if result is not None:
+                open_ports.append(result)
+    return sorted(open_ports)
+
+
+def describe_services(open_ports: Iterable[int]) -> None:
+    """Print a list of open ports with their known services."""
+    print("\nOpen Ports Detected:")
+    for port in open_ports:
+        name, _ = SERVICE_TIPS.get(port, ("Unknown", ""))
+        print(f"- {port}: {name}")
+
+
+def recon_suggestions(open_ports: Iterable[int]) -> None:
+    """Print basic recon tips for each detected service."""
+    print("\nRecon Tips:")
+    for port in open_ports:
+        name, tip = SERVICE_TIPS.get(port, ("Unknown", "No tips available."))
+        print(f"- {port} ({name}): {tip}")
+
+
+def interactive_menu(open_ports: List[int]) -> None:
+    """Display a simple post-scan menu for educational purposes."""
+    if not open_ports:
+        print("No open ports to analyze.")
+        return
+
+    while True:
+        print("\nWhat would you like to do?")
+        print("[1] Print common service behavior")
+        print("[2] Print recon tips for each service")
+        print("[3] Exit")
+        choice = input("> ").strip()
+        if choice == "1":
+            describe_services(open_ports)
+        elif choice == "2":
+            recon_suggestions(open_ports)
+        elif choice == "3":
+            break
+        else:
+            print("Invalid choice. Please select 1, 2, or 3.")


### PR DESCRIPTION
## Summary
- improve port scanner with multithreading
- offer post‑scan interactive menu showing service info and recon tips
- update CLI to call interactive menu
- document new behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cbe3863e0832eabe5894f6fc88d81