### PR TITLE
Add port scan command to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@ Run `blizz` to launch the interface and start chatting:
 ./blizz
 ```
 
-You can also run the built-in port scanner with:
+You can also run the built-in port scanner from the command line or from inside
+the chat session. To scan from the command line use:
 
 ```bash
 ./blizz scan <target>
+```
+
+Within the chat you can trigger the same scanner by prefixing the command with
+an exclamation mark:
+
+```text
+!scan <target> [--ports 80,443]
 ```
 
 After scanning, an interactive menu lets you display common service names or

--- a/src/modules/command_executor.py
+++ b/src/modules/command_executor.py
@@ -14,7 +14,18 @@ def lazy_import_self_improvement():
 
 def execute_command(command):
     """Secure command execution using a whitelist approach."""
-    allowed_commands = ["ls", "pwd", "whoami", "df", "free", "uptime", "echo", "cat", "self_improve"]
+    allowed_commands = [
+        "ls",
+        "pwd",
+        "whoami",
+        "df",
+        "free",
+        "uptime",
+        "echo",
+        "cat",
+        "self_improve",
+        "scan",
+    ]
 
     try:
         command_parts = shlex.split(command)
@@ -36,6 +47,28 @@ def execute_command(command):
             return "Usage: self_improve <file_path>"
         self_improve = lazy_import_self_improvement()  # ✅ Import only when needed
         return self_improve.self_improve_code(command_parts[1])
+
+    if command_parts[0] == "scan":
+        from modules import port_scanner  # Local import to avoid overhead
+        if len(command_parts) < 2:
+            return "Usage: scan <target> [--ports 80,443]"
+        target = command_parts[1]
+        ports = None
+        if "--ports" in command_parts:
+            idx = command_parts.index("--ports")
+            if idx + 1 >= len(command_parts):
+                return "Usage: scan <target> [--ports 80,443]"
+            try:
+                ports = [int(p) for p in command_parts[idx + 1].split(',') if p.strip()]
+            except ValueError:
+                return "Error: ports must be integers"
+        open_ports = port_scanner.scan_target(target, ports)
+        if open_ports:
+            msg = f"Open ports on {target}: {', '.join(map(str, open_ports))}"
+        else:
+            msg = f"No open ports found on {target}"
+        port_scanner.interactive_menu(open_ports)
+        return msg
 
     for arg in command_parts[1:]:
         if any(symbol in arg for symbol in [';', '&', '|', '$', '>', '<']):

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,5 +1,9 @@
 import os
 from pathlib import Path
+import socket
+import threading
+
+import modules.port_scanner as port_scanner
 
 import modules.command_executor as command_executor
 
@@ -20,3 +24,23 @@ def test_execute_command_path_traversal(tmp_path):
     rel_path = os.path.relpath(secret_file, os.getcwd())
     output = command_executor.execute_command(f"cat {rel_path}")
     assert "secret" in output
+
+
+def _start_dummy_server(host="localhost"):
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind((host, 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    thread = threading.Thread(target=server.accept, daemon=True)
+    thread.start()
+    return server, port
+
+
+def test_execute_command_scan(monkeypatch):
+    server, port = _start_dummy_server()
+    monkeypatch.setattr(port_scanner, "interactive_menu", lambda ports: None)
+    try:
+        output = command_executor.execute_command(f"scan localhost --ports {port}")
+        assert str(port) in output
+    finally:
+        server.close()


### PR DESCRIPTION
## Summary
- allow running the port scanner from inside chat via `!scan`
- document new usage in the README
- extend command executor with `scan` handling
- add tests for the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc40e83e8832eb7dba51ae825aabd