### PR TITLE
Add optional threader and nmap scanning modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,23 @@ You can also run the built-in port scanner from the command line or from inside
 the chat session. To scan from the command line use:
 
 ```bash
-./blizz scan <target>
+./blizz scan <target> [--method nmap]
 ```
 
 Within the chat you can trigger the same scanner by prefixing the command with
 an exclamation mark:
 
 ```text
-!scan <target> [--ports 80,443]
+!scan <target> [--ports 80,443] [--method threader|nmap]
 ```
 
 After scanning, an interactive menu lets you display common service names or
 basic recon tips for the detected ports. Use this only on systems you have
 explicit permission to test.
+
+The scanner now supports additional methods. Use `--method threader` to
+emulate the behaviour of the threader3000 project or `--method nmap` to invoke
+the `nmap` utility for more detailed results.
 
 The script displays a welcome banner, processes any stored memory, and then enters a chat loop where you can interact with the bot. Type `exit` to leave the chat.
 

--- a/src/blizz_cli.py
+++ b/src/blizz_cli.py
@@ -21,12 +21,18 @@ def main() -> None:
     scan_parser.add_argument(
         "--ports", help="Comma-separated list of ports", default=None
     )
+    scan_parser.add_argument(
+        "--method",
+        choices=["default", "threader", "nmap"],
+        default="default",
+        help="Scanning method to use",
+    )
 
     args = parser.parse_args()
 
     if args.command == "scan":
         ports = parse_ports(args.ports) if args.ports else None
-        open_ports = scan_target(args.target, ports)
+        open_ports = scan_target(args.target, ports, method=args.method)
         if open_ports:
             print(f"Open ports on {args.target}: {', '.join(map(str, open_ports))}")
         else:

--- a/src/modules/command_executor.py
+++ b/src/modules/command_executor.py
@@ -51,18 +51,28 @@ def execute_command(command):
     if command_parts[0] == "scan":
         from modules import port_scanner  # Local import to avoid overhead
         if len(command_parts) < 2:
-            return "Usage: scan <target> [--ports 80,443]"
+            return "Usage: scan <target> [--ports 80,443] [--method METHOD]"
         target = command_parts[1]
         ports = None
+        method = "default"
         if "--ports" in command_parts:
             idx = command_parts.index("--ports")
             if idx + 1 >= len(command_parts):
-                return "Usage: scan <target> [--ports 80,443]"
+                return "Usage: scan <target> [--ports 80,443] [--method METHOD]"
             try:
                 ports = [int(p) for p in command_parts[idx + 1].split(',') if p.strip()]
             except ValueError:
                 return "Error: ports must be integers"
-        open_ports = port_scanner.scan_target(target, ports)
+        if "--method" in command_parts:
+            idx = command_parts.index("--method")
+            if idx + 1 >= len(command_parts):
+                return "Usage: scan <target> [--ports 80,443] [--method METHOD]"
+            method = command_parts[idx + 1]
+        elif "--nmap" in command_parts:
+            method = "nmap"
+        elif "--threader" in command_parts:
+            method = "threader"
+        open_ports = port_scanner.scan_target(target, ports, method=method)
         if open_ports:
             msg = f"Open ports on {target}: {', '.join(map(str, open_ports))}"
         else:

--- a/tests/test_port_scanner.py
+++ b/tests/test_port_scanner.py
@@ -26,3 +26,13 @@ def test_scan_detects_open_port():
 def test_scan_closed_port():
     result = port_scanner.scan_target("localhost", [65534])
     assert result == []
+
+
+def test_threader_scan(monkeypatch):
+    server, port = _start_dummy_server()
+    monkeypatch.setattr(port_scanner, "interactive_menu", lambda ports: None)
+    try:
+        result = port_scanner.scan_target("localhost", [port], method="threader")
+        assert port in result
+    finally:
+        server.close()


### PR DESCRIPTION
## Summary
- extend port scanner with `threader_scan` and `nmap_scan`
- allow specifying scan method from CLI and chat
- interactive menu can now launch `nmap` on discovered ports
- document new options in the README
- cover threader mode in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccd27fa74832ebd42f3fd57135451