### PR TITLE
Add emoji opt-in feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The script displays a welcome banner, processes any stored memory, and then ente
 
 Several files control various aspects of the system:
 
-- `src/config/neocortex.json` – main configuration for the bot (model selection, memory limits, greeting behaviour, etc.).
+- `src/config/neocortex.json` – main configuration for the bot (model selection, memory limits, greeting behaviour, etc.). Set `"use_emoji": true` to append a friendly emoji to every reply.
 - `src/config/interface_config.json` – settings for the terminal interface such as the banner text and welcome message.
 - `src/models/memory.json` – raw conversation history saved across sessions.
 - `src/models/processed_memory.json` – structured data produced by the memory processor.

--- a/src/config/neocortex.json
+++ b/src/config/neocortex.json
@@ -7,6 +7,7 @@
     "model": "gpt-4o",
     "log_level": "debug",
     "conversation_tone": "engaging",
+    "use_emoji": false,
     "memory_retrieval": {
         "strategy": "relevant",
         "keywords_priority": true,

--- a/src/modules/chat_handler.py
+++ b/src/modules/chat_handler.py
@@ -54,21 +54,26 @@ def generate_contextual_response(user_input: str) -> str | None:
 
 def handle_user_input(user_input):
     """Process a single exchange and return the bot's response."""
+    config = load_neocortex_config()
     structured_memory = retrieve_processed_memory()
     conversation_history = structured_memory.get("conversation_history", [])
     event_logger.log_event("user_input", {"text": user_input})
 
     # Get guidance from Neuron
-    guidance = neuron_advice(user_input, conversation_history, load_neocortex_config())
+    guidance = neuron_advice(user_input, conversation_history, config)
     combined_prompt = f"Neuron's guidance: {guidance}\n\nUser: {user_input}\nBot:"
 
     # Use the pre-initialized AI model
     response = main_bot.invoke(combined_prompt)
 
+    response_text = response.content
+    if config.get("use_emoji"):
+        response_text += " 😊"
+
     # Save conversation context
-    memory.save_context(user_input, response.content)
-    event_logger.log_event("bot_response", {"text": response.content})
-    return response.content
+    memory.save_context(user_input, response_text)
+    event_logger.log_event("bot_response", {"text": response_text})
+    return response_text
 
 def chat_loop():
     """Main chat loop that handles each conversation exchange."""

--- a/tests/test_use_emoji.py
+++ b/tests/test_use_emoji.py
@@ -1,0 +1,21 @@
+import types
+import modules.chat_handler as chat_handler
+
+
+def test_handle_user_input_appends_emoji(monkeypatch):
+    # config with emoji enabled
+    monkeypatch.setattr(chat_handler, "load_neocortex_config", lambda: {"use_emoji": True})
+
+    class FakeModel:
+        def invoke(self, prompt):
+            return types.SimpleNamespace(content="hello")
+
+    monkeypatch.setattr(chat_handler, "main_bot", FakeModel())
+    monkeypatch.setattr(chat_handler, "retrieve_processed_memory", lambda: {"conversation_history": []})
+    monkeypatch.setattr(chat_handler, "neuron_advice", lambda *args, **kwargs: "")
+    monkeypatch.setattr(chat_handler, "memory", types.SimpleNamespace(save_context=lambda *a, **k: None))
+    monkeypatch.setattr(chat_handler.event_logger, "log_event", lambda *a, **k: None)
+
+    result = chat_handler.handle_user_input("hi")
+    assert "hello" in result
+    assert "😊" in result


### PR DESCRIPTION
## Summary
- add `use_emoji` setting to `neocortex.json`
- optionally append a friendly emoji in `chat_handler.handle_user_input`
- document emoji flag in README
- add unit test for emoji behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d069ad164832ebd11662fa46c4922