### PR TITLE
Add py_modules to setuptools config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ blizz = "blizz_cli:main"
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = ["modules", "config", "models"]
+py_modules = ["blizz_cli", "main"]


### PR DESCRIPTION
## Summary
- ensure blizz_cli and main are installed as modules

## Testing
- `pytest -q`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_684d142f65dc832e80f84fbd197e4edc