### PR TITLE
Improve GUI launcher with auto-dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,21 @@ Run `blizz` to launch the interface and start chatting:
 ./blizz
 ```
 
-To open the optional graphical interface, run:
+To open the graphical interface, run:
 
 ```bash
-./blizz gui
+./blizz --gui
 ```
 
-This GUI is built with Tkinter and may require the `python3-tk` package
-(or your platform's Tkinter package) to be installed.
+This command automatically checks for Tkinter and attempts to install it if
+needed. If installation fails, install your platform's Tkinter package
+(often `python3-tk` on Debian/Ubuntu) and re-run the command. The older
+syntax `./blizz gui` still works as well.
+
+When it runs, a window appears showing the chat log, an input box and extra
+panes for suggestions and guidance.
+
+For a full list of commands and options run `./blizz --help`.
 
 You can also run the built-in port scanner from the command line or from inside
 the chat session. To scan from the command line use:

--- a/src/blizz_cli.py
+++ b/src/blizz_cli.py
@@ -1,4 +1,7 @@
 import argparse
+import importlib
+import subprocess
+import sys
 from typing import List
 
 from main import main as run_chat
@@ -9,9 +12,30 @@ def parse_ports(port_str: str) -> List[int]:
     return [int(p) for p in port_str.split(",") if p.strip()]
 
 
+def ensure_gui_dependencies() -> None:
+    """Ensure Tkinter is available for the GUI."""
+    try:
+        importlib.import_module("tkinter")
+    except ModuleNotFoundError:
+        print("Tkinter not found. Attempting to install...", file=sys.stderr)
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "tk"])
+        except Exception:
+            print(
+                "Automatic installation failed. Install 'python3-tk' or your platform's Tkinter package.",
+                file=sys.stderr,
+            )
+            raise
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="blizz", description="Blizz command line interface"
+    )
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help="Launch the graphical interface",
     )
     subparsers = parser.add_subparsers(dest="command")
 
@@ -33,6 +57,12 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if args.gui:
+        ensure_gui_dependencies()
+        from blizz_gui import main as launch_gui
+        launch_gui()
+        return
+
     if args.command == "scan":
         ports = parse_ports(args.ports) if args.ports else None
         open_ports = scan_target(args.target, ports, method=args.method)
@@ -42,6 +72,7 @@ def main() -> None:
             print(f"No open ports found on {args.target}")
         interactive_menu(open_ports)
     elif args.command == "gui":
+        ensure_gui_dependencies()
         from blizz_gui import main as launch_gui
         launch_gui()
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,18 @@ def test_gui_command(monkeypatch):
     blizz_cli.main()
 
     assert called["ran"]
+
+
+def test_gui_flag(monkeypatch):
+    called = {"ran": False}
+
+    def fake_run_gui():
+        called["ran"] = True
+
+    monkeypatch.setattr(blizz_gui, "main", fake_run_gui)
+    monkeypatch.setattr(blizz_cli, "ensure_gui_dependencies", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["blizz", "--gui"])
+
+    blizz_cli.main()
+
+    assert called["ran"]


### PR DESCRIPTION
## Summary
- add `--gui` flag to launch GUI from anywhere
- automatically install Tkinter if missing via `ensure_gui_dependencies`
- document GUI launch workflow and troubleshooting steps in README
- support `--gui` in CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4e90d64c832e8f8a368bdd7dca1f