### PR TITLE
Enable Enter key to send in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This command automatically checks for Tkinter and attempts to install it if need
 
 
 When it runs, a window appears showing the chat log, an input box and extra
-panes for suggestions and guidance.
+panes for suggestions and guidance. Press **Enter** anywhere in the window to
+send your message or click the **Send** button.
 
 For a full list of commands and options run `./blizz --help`.
 

--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -18,7 +18,9 @@ class BlizzGUI:
 
         self.input_entry = tk.Entry(root, width=80)
         self.input_entry.pack(padx=5, pady=(0, 5))
-        self.input_entry.bind("<Return>", self.handle_input)
+
+        # Allow pressing Enter anywhere in the window to send the message
+        root.bind("<Return>", self.handle_input)
 
         send_button = tk.Button(root, text="Send", command=self.handle_input)
         send_button.pack(pady=(0, 5))


### PR DESCRIPTION
## Summary
- allow pressing Enter anywhere in the GUI window to send a message
- document Enter key support in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564355e220832e9f0bb084c440afb5