### PR TITLE
Enhance GUI with tabbed sessions

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -1,45 +1,35 @@
+import json
 import re
 from pathlib import Path
 import tkinter as tk
+from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 
 from modules.chat_handler import generate_contextual_response, handle_user_input
 from modules.command_executor import execute_command
 
 
-class BlizzGUI:
-    """Simple Tkinter interface for the chat assistant."""
+class ChatSession:
+    """Representation of a single chat session."""
 
-    def __init__(self, root: tk.Tk) -> None:
-        self.root = root
-        root.title("Blizz Beta")
-        root.configure(bg="#1e1e1e")
+    def __init__(self, gui: "BlizzGUI", parent: ttk.Notebook, session_id: int) -> None:
+        self.gui = gui
+        self.session_id = session_id
+        self.frame = tk.Frame(parent, bg="#1e1e1e")
 
-        logo_frame = tk.Frame(root, bg="#1e1e1e")
-        logo_frame.pack(pady=(10, 5))
-        logo_path = Path(__file__).resolve().parent.parent / "assets" / "blizz_netic_logo.png"
-        self.logo_img = tk.PhotoImage(file=str(logo_path))
-        logo_label = tk.Label(logo_frame, image=self.logo_img, bg="#1e1e1e")
-        logo_label.pack()
+        self.file_path = Path(__file__).resolve().parent.parent / "sessions" / f"session_{session_id}.json"
+        self.file_path.parent.mkdir(exist_ok=True)
 
-        common_opts = {
-            "font": ("Courier New", 10),
-            "fg": "#00ffcc",
-            "bg": "#1e1e1e",
-        }
-
-        self.chat_log = ScrolledText(root, width=80, height=20, state="disabled", **common_opts)
+        opts = gui.common_opts
+        self.chat_log = ScrolledText(self.frame, width=80, height=20, state="disabled", **opts)
         self.chat_log.pack(padx=10, pady=5)
 
-        self.input_entry = tk.Entry(root, width=80, **common_opts)
+        self.input_entry = tk.Entry(self.frame, width=80, **opts)
         self.input_entry.configure(insertbackground="#00ffcc")
         self.input_entry.pack(padx=10, pady=(0, 5))
 
-        # Allow pressing Enter anywhere in the window to send the message
-        root.bind("<Return>", self.handle_input)
-
         send_button = tk.Button(
-            root,
+            self.frame,
             text="Send",
             command=self.handle_input,
             bg="#1e1e1e",
@@ -47,11 +37,17 @@ class BlizzGUI:
         )
         send_button.pack(padx=10, pady=(0, 5))
 
-        self.suggestion_box = ScrolledText(root, width=80, height=5, state="disabled", **common_opts)
+        self.suggestion_box = ScrolledText(self.frame, width=80, height=5, state="disabled", **opts)
         self.suggestion_box.pack(padx=10, pady=5)
 
-        self.guidance_box = ScrolledText(root, width=80, height=5, state="disabled", **common_opts)
+        # Guidance window per session
+        self.guidance_window = tk.Toplevel(gui.root)
+        self.guidance_window.title(f"Guidance {session_id}")
+        self.guidance_window.configure(bg="#1e1e1e")
+        self.guidance_box = ScrolledText(self.guidance_window, width=80, height=5, state="disabled", **opts)
         self.guidance_box.pack(padx=10, pady=5)
+
+        self.load_history()
 
     def _append_text(self, widget: ScrolledText, text: str) -> None:
         widget.configure(state="normal")
@@ -59,12 +55,37 @@ class BlizzGUI:
         widget.configure(state="disabled")
         widget.see(tk.END)
 
+    def save_history(self, user: str, bot: str) -> None:
+        data = []
+        if self.file_path.exists():
+            try:
+                with open(self.file_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except json.JSONDecodeError:
+                data = []
+        data.append({"user": user, "bot": bot})
+        with open(self.file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4)
+
+    def load_history(self) -> None:
+        self.chat_log.configure(state="normal")
+        self.chat_log.delete("1.0", tk.END)
+        if self.file_path.exists():
+            try:
+                with open(self.file_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                for entry in data:
+                    self.chat_log.insert(tk.END, f"You: {entry.get('user','')}\n")
+                    self.chat_log.insert(tk.END, f"Bot: {entry.get('bot','')}\n")
+            except json.JSONDecodeError:
+                pass
+        self.chat_log.configure(state="disabled")
+
     def update_boxes(self, response: str) -> None:
-        """Update the Suggested Response and Guidance boxes."""
         suggestion = ""
         guidance = ""
 
-        match = re.search(r"Suggested Response:\s*(.*?)(?:\n\s*[\ud83c-\udfff]* ?Guidance:|$)", response, re.S)
+        match = re.search(r"Suggested Response:\s*(.*?)(?:\n\s*[\ud83c-\udfff]*?Guidance:|$)", response, re.S)
         if match:
             suggestion = match.group(1).strip()
 
@@ -94,7 +115,7 @@ class BlizzGUI:
         self.chat_log.yview(tk.END)
 
         if user_text.lower() == "exit":
-            self.root.quit()
+            self.gui.root.quit()
             return
 
         if user_text.startswith("!"):
@@ -106,6 +127,59 @@ class BlizzGUI:
         self._append_text(self.chat_log, f"Bot: {response}\n")
         self.chat_log.yview(tk.END)
         self.update_boxes(response)
+        self.save_history(user_text, response)
+
+
+class BlizzGUI:
+    """Tkinter interface supporting multiple chat sessions."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        root.title("Blizz Beta")
+        root.configure(bg="#1e1e1e")
+
+        header = tk.Frame(root, bg="#1e1e1e")
+        header.pack(anchor="nw", pady=(5, 0))
+        logo_path = Path(__file__).resolve().parent.parent / "assets" / "blizz_netic_logo.png"
+        try:
+            self.logo_img = tk.PhotoImage(file=str(logo_path))
+            self.logo_small = self.logo_img.subsample(4, 4)
+            tk.Label(header, image=self.logo_small, bg="#1e1e1e").pack(side="left", padx=(10, 5))
+        except Exception:
+            tk.Label(header, text="Blizz", bg="#1e1e1e", fg="#00ffcc").pack(side="left", padx=(10, 5))
+
+        new_button = tk.Button(header, text="New Chat", command=self.add_session, bg="#1e1e1e", fg="#00ffcc")
+        new_button.pack(side="left")
+
+        self.common_opts = {
+            "font": ("Courier New", 10),
+            "fg": "#00ffcc",
+            "bg": "#1e1e1e",
+        }
+
+        self.notebook = ttk.Notebook(root)
+        self.notebook.pack(expand=True, fill="both")
+        self.notebook.bind("<<NotebookTabChanged>>", self._on_tab_change)
+
+        self.sessions: list[ChatSession] = []
+        self.current_session: ChatSession | None = None
+
+        self.add_session()
+        root.bind("<Return>", lambda e: self.current_session.handle_input() if self.current_session else None)
+
+    def add_session(self) -> None:
+        session_id = len(self.sessions) + 1
+        session = ChatSession(self, self.notebook, session_id)
+        self.sessions.append(session)
+        self.notebook.add(session.frame, text=f"Chat {session_id}")
+        self.notebook.select(session.frame)
+        self.current_session = session
+
+    def _on_tab_change(self, event=None) -> None:
+        idx = self.notebook.index("current")
+        if 0 <= idx < len(self.sessions):
+            self.current_session = self.sessions[idx]
+            self.current_session.load_history()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- support multiple chat sessions via `ttk.Notebook`
- create a `ChatSession` class that stores its history in JSON files
- add guidance window per session
- display blizz_netic_logo.png in the header and allow starting new chats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564a3b3e90832eb293853289e96f30