### PR TITLE
Implement session lifecycle and guidance pane features

### DIFF
--- a/src/blizz_cli.py
+++ b/src/blizz_cli.py
@@ -51,7 +51,8 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command")
 
-    subparsers.add_parser("chat", help="Start chat (default)")
+    chat_parser = subparsers.add_parser("chat", help="Start chat (default)")
+    chat_parser.add_argument("--delete", type=int, help="Delete chat by id")
 
     # Register the GUI launcher so `blizz gui` works from the CLI
     subparsers.add_parser("gui", help="Launch the GUI")
@@ -87,6 +88,11 @@ def main() -> None:
         ensure_gui_dependencies()
         from blizz_gui import main as launch_gui
         launch_gui()
+    elif args.command == "chat" and args.delete:
+        from modules import chat_db
+
+        chat_db.delete_chat(args.delete)
+        print(f"Deleted chat {args.delete}")
     else:
         run_chat()
 

--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -1,12 +1,16 @@
 import json
 import re
+import threading
 from pathlib import Path
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox, simpledialog
 from tkinter.scrolledtext import ScrolledText
 
 from modules.chat_handler import generate_contextual_response, handle_user_input
 from modules.command_executor import execute_command
+from modules.port_scanner import scan_target
+from modules import chat_db, summarizer
+from modules.guidance_api import guidance_api
 
 
 class ChatSession:
@@ -17,7 +21,7 @@ class ChatSession:
         self.session_id = session_id
         self.frame = tk.Frame(parent, bg="#1e1e1e")
 
-        self.file_path = Path(__file__).resolve().parent.parent / "sessions" / f"session_{session_id}.json"
+        self.file_path = Path(__file__).resolve().parent.parent / "sessions" / f"session_{session_id}.jsonl"
         self.file_path.parent.mkdir(exist_ok=True)
 
         opts = gui.common_opts
@@ -40,14 +44,33 @@ class ChatSession:
         self.suggestion_box = ScrolledText(self.frame, width=80, height=5, state="disabled", **opts)
         self.suggestion_box.pack(padx=10, pady=5)
 
-        # Guidance window per session
-        self.guidance_window = tk.Toplevel(gui.root)
-        self.guidance_window.title(f"Guidance {session_id}")
-        self.guidance_window.configure(bg="#1e1e1e")
-        self.guidance_box = ScrolledText(self.guidance_window, width=80, height=5, state="disabled", **opts)
+        self.guidance_box = ScrolledText(self.frame, width=80, height=5, state="disabled", **opts)
         self.guidance_box.pack(padx=10, pady=5)
+        guidance_api.set_widget(self.guidance_box)
+
+        close_btn = tk.Button(
+            self.frame,
+            text="Close",
+            command=self.close_session,
+            bg="#1e1e1e",
+            fg="#00ffcc",
+        )
+        close_btn.pack(padx=10, pady=(0, 5))
 
         self.load_history()
+
+    def cleanup(self) -> None:
+        if self.file_path.exists():
+            self.file_path.unlink()
+        msgs = chat_db.get_messages(self.session_id)
+        threading.Thread(
+            target=summarizer.summarize_messages, args=(self.session_id, msgs)
+        ).start()
+        chat_db.delete_chat(self.session_id)
+
+    def close_session(self) -> None:
+        if messagebox.askyesno("Close Chat", "Delete this chat?"):
+            self.gui.delete_session(self)
 
     def _append_text(self, widget: ScrolledText, text: str) -> None:
         widget.configure(state="normal")
@@ -55,17 +78,10 @@ class ChatSession:
         widget.configure(state="disabled")
         widget.see(tk.END)
 
-    def save_history(self, user: str, bot: str) -> None:
-        data = []
-        if self.file_path.exists():
-            try:
-                with open(self.file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-            except json.JSONDecodeError:
-                data = []
-        data.append({"user": user, "bot": bot})
-        with open(self.file_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4)
+    def append_history(self, role: str, text: str) -> None:
+        with open(self.file_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"role": role, "text": text}) + "\n")
+        chat_db.record_message(self.session_id, role, text)
 
     def load_history(self) -> None:
         self.chat_log.configure(state="normal")
@@ -73,10 +89,12 @@ class ChatSession:
         if self.file_path.exists():
             try:
                 with open(self.file_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                for entry in data:
-                    self.chat_log.insert(tk.END, f"You: {entry.get('user','')}\n")
-                    self.chat_log.insert(tk.END, f"Bot: {entry.get('bot','')}\n")
+                    for line in f:
+                        entry = json.loads(line)
+                        role = entry.get("role", "")
+                        text = entry.get("text", "")
+                        prefix = "You" if role == "user" else "Bot"
+                        self.chat_log.insert(tk.END, f"{prefix}: {text}\n")
             except json.JSONDecodeError:
                 pass
         self.chat_log.configure(state="disabled")
@@ -101,9 +119,9 @@ class ChatSession:
 
         self.guidance_box.configure(state="normal")
         self.guidance_box.delete("1.0", tk.END)
-        if guidance:
-            self.guidance_box.insert(tk.END, guidance + "\n")
         self.guidance_box.configure(state="disabled")
+        if guidance:
+            guidance_api.push(guidance)
 
     def handle_input(self, event=None) -> None:  # type: ignore[override]
         user_text = self.input_entry.get().strip()
@@ -113,6 +131,7 @@ class ChatSession:
         self.input_entry.delete(0, tk.END)
         self._append_text(self.chat_log, f"You: {user_text}\n")
         self.chat_log.yview(tk.END)
+        self.append_history("user", user_text)
 
         if user_text.lower() == "exit":
             self.gui.root.quit()
@@ -127,7 +146,7 @@ class ChatSession:
         self._append_text(self.chat_log, f"Bot: {response}\n")
         self.chat_log.yview(tk.END)
         self.update_boxes(response)
-        self.save_history(user_text, response)
+        self.append_history("bot", response)
 
 
 class BlizzGUI:
@@ -151,6 +170,9 @@ class BlizzGUI:
         new_button = tk.Button(header, text="New Chat", command=self.add_session, bg="#1e1e1e", fg="#00ffcc")
         new_button.pack(side="left")
 
+        scan_button = tk.Button(header, text="Scan", command=self.scan_prompt, bg="#1e1e1e", fg="#00ffcc")
+        scan_button.pack(side="left", padx=(5, 0))
+
         self.common_opts = {
             "font": ("Courier New", 10),
             "fg": "#00ffcc",
@@ -164,7 +186,10 @@ class BlizzGUI:
         self.sessions: list[ChatSession] = []
         self.current_session: ChatSession | None = None
 
-        self.add_session()
+        self._rehydrate_sessions()
+        if not self.sessions:
+            self.add_session()
+
         root.bind("<Return>", lambda e: self.current_session.handle_input() if self.current_session else None)
 
     def add_session(self) -> None:
@@ -175,11 +200,47 @@ class BlizzGUI:
         self.notebook.select(session.frame)
         self.current_session = session
 
+    def delete_session(self, session: ChatSession) -> None:
+        idx = self.sessions.index(session)
+        self.notebook.forget(session.frame)
+        session.cleanup()
+        self.sessions.remove(session)
+        if self.sessions:
+            self.current_session = self.sessions[max(0, idx - 1)]
+            self.notebook.select(self.current_session.frame)
+        else:
+            self.add_session()
+
+    def _rehydrate_sessions(self) -> None:
+        sessions_dir = Path(__file__).resolve().parent.parent / "sessions"
+        for path in sorted(sessions_dir.glob("session_*.jsonl")):
+            sid = int(re.search(r"(\d+)", path.stem).group(1))
+            session = ChatSession(self, self.notebook, sid)
+            self.sessions.append(session)
+            self.notebook.add(session.frame, text=f"Chat {sid}")
+        if self.sessions:
+            self.notebook.select(self.sessions[0].frame)
+            self.current_session = self.sessions[0]
+            guidance_api.set_widget(self.current_session.guidance_box)
+
+    def scan_prompt(self) -> None:
+        target = simpledialog.askstring("Scan", "Target?")
+        if not target:
+            return
+        ports = scan_target(target)
+        msg = (
+            f"Scan results for {target}: {', '.join(map(str, ports))}"
+            if ports
+            else f"No open ports on {target}"
+        )
+        guidance_api.push(msg)
+
     def _on_tab_change(self, event=None) -> None:
         idx = self.notebook.index("current")
         if 0 <= idx < len(self.sessions):
             self.current_session = self.sessions[idx]
             self.current_session.load_history()
+            guidance_api.set_widget(self.current_session.guidance_box)
 
 
 def main() -> None:

--- a/src/modules/chat_db.py
+++ b/src/modules/chat_db.py
@@ -1,0 +1,53 @@
+import sqlite3
+from pathlib import Path
+from datetime import datetime
+
+_DB_PATH = Path(__file__).resolve().parent.parent / "models" / "chat_history.db"
+
+_connection = None
+
+def _get_conn():
+    global _connection
+    if _connection is None:
+        _connection = sqlite3.connect(_DB_PATH)
+        _connection.execute(
+            "CREATE TABLE IF NOT EXISTS messages (chat_id INTEGER, timestamp TEXT, role TEXT, message TEXT)"
+        )
+        _connection.execute(
+            "CREATE TABLE IF NOT EXISTS summaries (chat_id INTEGER, timestamp TEXT, summary_text TEXT)"
+        )
+        _connection.commit()
+    return _connection
+
+
+def record_message(chat_id: int, role: str, message: str) -> None:
+    conn = _get_conn()
+    conn.execute(
+        "INSERT INTO messages (chat_id, timestamp, role, message) VALUES (?, ?, ?, ?)",
+        (chat_id, datetime.utcnow().isoformat() + "Z", role, message),
+    )
+    conn.commit()
+
+
+def get_messages(chat_id: int):
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT role, message FROM messages WHERE chat_id=? ORDER BY rowid", (chat_id,)
+    )
+    return cur.fetchall()
+
+
+def delete_chat(chat_id: int) -> None:
+    conn = _get_conn()
+    conn.execute("DELETE FROM messages WHERE chat_id=?", (chat_id,))
+    conn.execute("DELETE FROM summaries WHERE chat_id=?", (chat_id,))
+    conn.commit()
+
+
+def record_summary(chat_id: int, summary: str) -> None:
+    conn = _get_conn()
+    conn.execute(
+        "INSERT INTO summaries (chat_id, timestamp, summary_text) VALUES (?, ?, ?)",
+        (chat_id, datetime.utcnow().isoformat() + "Z", summary),
+    )
+    conn.commit()

--- a/src/modules/guidance_api.py
+++ b/src/modules/guidance_api.py
@@ -1,0 +1,19 @@
+from tkinter.scrolledtext import ScrolledText
+
+
+class GuidancePane:
+    def __init__(self) -> None:
+        self.widget: ScrolledText | None = None
+
+    def set_widget(self, widget: ScrolledText | None) -> None:
+        self.widget = widget
+
+    def push(self, text: str) -> None:
+        if self.widget is None:
+            return
+        self.widget.configure(state="normal")
+        self.widget.insert("end", text + "\n")
+        self.widget.configure(state="disabled")
+        self.widget.see("end")
+
+guidance_api = GuidancePane()

--- a/src/modules/summarizer.py
+++ b/src/modules/summarizer.py
@@ -1,0 +1,8 @@
+from . import chat_db
+
+
+def summarize_messages(chat_id: int, messages) -> None:
+    """Create a naive summary of the provided messages and store it."""
+    text = " ".join(m[1] for m in messages)
+    summary = text[:200]
+    chat_db.record_summary(chat_id, summary)


### PR DESCRIPTION
## Summary
- persist chat messages and summaries in `chat_history.db`
- add guidance pane widget API
- support summarizing chats when a tab closes
- integrate close controls, scan button, and session rehydration in GUI
- extend CLI with `--delete` option for chat cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856566b4c70832e9abb9490908d303a