### PR TITLE
Add session guidance after CLI commands

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -138,7 +138,16 @@ class ChatSession:
             return
 
         if user_text.startswith("!"):
-            response = execute_command(user_text[1:].strip())
+            command = user_text[1:].strip()
+            response = execute_command(command)
+            try:
+                from modules.cli_guidance import synthesize_guidance
+
+                hint = synthesize_guidance(command, response)
+                if hint:
+                    guidance_api.push(hint)
+            except Exception:
+                pass
         else:
             ctx_resp = generate_contextual_response(user_text)
             response = ctx_resp if ctx_resp is not None else handle_user_input(user_text)

--- a/src/modules/cli_guidance.py
+++ b/src/modules/cli_guidance.py
@@ -1,0 +1,40 @@
+import re
+from modules.port_scanner import recon_suggestions_str, SERVICE_TIPS
+
+
+def _parse_scan_output(output: str) -> list[int]:
+    match = re.search(r"ports? on .*?:\s*([0-9 ,]+)", output)
+    if not match:
+        return []
+    ports: list[int] = []
+    for p in re.findall(r"\d+", match.group(1)):
+        try:
+            port = int(p)
+            if 0 < port <= 65535:
+                ports.append(port)
+        except ValueError:
+            continue
+    return ports
+
+
+def synthesize_guidance(command: str, output: str) -> str:
+    """Create a short hint for the given CLI command output."""
+    cmd = command.split()[0] if command else ""
+
+    if cmd == "scan":
+        ports = _parse_scan_output(output)
+        if ports:
+            tips = recon_suggestions_str(ports)
+            return f"Open ports found: {', '.join(map(str, ports))}\n{tips}"
+        return "Scan finished. No open ports detected."
+
+    if cmd == "sniper":
+        match = re.search(r"(scan_logs/\S+\.json)", output)
+        if match:
+            return f"Sn1per results saved to {match.group(1)}"
+
+    # Generic fallback: show first line of output
+    first_line = output.strip().splitlines()[0] if output.strip() else ""
+    if first_line:
+        return f"Command output: {first_line}"
+    return ""

--- a/src/modules/port_scanner.py
+++ b/src/modules/port_scanner.py
@@ -177,6 +177,15 @@ def recon_suggestions(open_ports: Iterable[int]) -> None:
         print(f"- {port} ({name}): {tip}")
 
 
+def recon_suggestions_str(open_ports: Iterable[int]) -> str:
+    """Return recon tips as a formatted string."""
+    lines = []
+    for port in open_ports:
+        name, tip = SERVICE_TIPS.get(port, ("Unknown", "No tips available."))
+        lines.append(f"- {port} ({name}): {tip}")
+    return "\n".join(lines)
+
+
 def interactive_menu(open_ports: List[int]) -> None:
     """Display a simple post-scan menu for educational purposes."""
     if not open_ports:

--- a/src/sniper_runner.py
+++ b/src/sniper_runner.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from datetime import datetime
 
+from modules.guidance_api import guidance_api
+
 SNIPER_OUTPUT_DIR = "scan_logs"
 
 
@@ -13,8 +15,10 @@ def run_sniper(ip: str):
     cmd = f"sniper -t {ip} -o {output_file} -f json"
     subprocess.run(cmd, shell=True)
     if os.path.exists(output_file):
+        guidance_api.push(f"Sn1per results saved to {output_file}")
         with open(output_file, "r") as f:
             return json.load(f)
+    guidance_api.push("Sn1per scan failed")
     return {"error": "Scan failed or output not generated."}
 
 


### PR DESCRIPTION
## Summary
- parse CLI output to craft tips
- push hints to the guidance pane after executing commands
- provide recon tips helper for port scans
- notify user when Sn1per logs are created

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856590ad27c832e93658432eb158895