### PR TITLE
Handle existing event loop for async scan

### DIFF
--- a/src/modules/port_scanner.py
+++ b/src/modules/port_scanner.py
@@ -146,7 +146,22 @@ def scan_target(
         return threader_scan(target, ports, timeout, max_workers)
 
     if method == "async":
-        return asyncio.run(asyncio_scan(target, ports, timeout))
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            return asyncio.run(asyncio_scan(target, ports, timeout))
+
+        if loop.is_running():
+            new_loop = asyncio.new_event_loop()
+            try:
+                return new_loop.run_until_complete(asyncio_scan(target, ports, timeout))
+            finally:
+                new_loop.close()
+        else:
+            return loop.run_until_complete(asyncio_scan(target, ports, timeout))
 
     if ports is None:
         ports = range(1, 1025)

--- a/tests/test_port_scanner.py
+++ b/tests/test_port_scanner.py
@@ -1,5 +1,6 @@
 import socket
 import threading
+import asyncio
 
 import modules.port_scanner as port_scanner
 
@@ -46,3 +47,17 @@ def test_async_scan(monkeypatch):
         assert port in result
     finally:
         server.close()
+
+
+def test_async_scan_with_existing_loop(monkeypatch):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    server, port = _start_dummy_server()
+    monkeypatch.setattr(port_scanner, "interactive_menu", lambda ports: None)
+    try:
+        result = port_scanner.scan_target("localhost", [port], method="async")
+        assert port in result
+    finally:
+        server.close()
+        loop.close()
+        asyncio.set_event_loop(None)


### PR DESCRIPTION
## Summary
- support running async scans when an event loop already exists
- add regression test ensuring preexisting loops work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565c7f9fa4832e9833c8c891f64eaf