### PR TITLE
Add testing disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ JSON configuration files.  A mission statement located in
 `src/models/bot_mission.json` is injected into every prompt so the assistant is
 aware of its hacking mindset.
 
+For authorized testing only.
+
 ## Setup
 
 1. Create and activate a Python 3 virtual environment (optional but recommended).

--- a/src/blizz_cli.py
+++ b/src/blizz_cli.py
@@ -32,6 +32,7 @@ def ensure_gui_dependencies() -> None:
 
 
 def main() -> None:
+    print("Warning: For authorized testing only.")
     # Handle the global --gui flag before parsing subcommands so it can be used
     # on its own without requiring "chat" or another command.
     if "--gui" in sys.argv:


### PR DESCRIPTION
## Summary
- add notice about authorized testing in README
- warn users from blizz_cli before executing commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565c7cfc4c832ea164fc7e9c19d32c