### PR TITLE
Implement memory limit trimming

### DIFF
--- a/src/models/custom_memory.py
+++ b/src/models/custom_memory.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from config.config_loader import load_neocortex_config
+
 class CustomMemory:
     def __init__(self, memory_file=os.path.join(os.path.dirname(__file__), "memory.json")):
         self.memory_file = memory_file
@@ -9,14 +11,27 @@ class CustomMemory:
                 json.dump([], f)
 
     def save_context(self, user_input, bot_response):
+        config = load_neocortex_config()
+        memory_limit = config.get("memory_limit")
+
         with open(self.memory_file, "r") as f:
             data = json.load(f)
+
+        new_entry = {"user": user_input, "bot": bot_response}
+
         if isinstance(data, list):
-            data.append({"user": user_input, "bot": bot_response})
+            data.append(new_entry)
+            if isinstance(memory_limit, int) and len(data) > memory_limit:
+                data = data[-memory_limit:]
         elif isinstance(data, dict) and "conversation_history" in data:
-            data["conversation_history"].append({"user": user_input, "bot": bot_response})
+            history = data["conversation_history"]
+            history.append(new_entry)
+            if isinstance(memory_limit, int) and len(history) > memory_limit:
+                history = history[-memory_limit:]
+            data["conversation_history"] = history
         else:
-            data = [{"user": user_input, "bot": bot_response}]
+            data = [new_entry]
+
         with open(self.memory_file, "w") as f:
             json.dump(data, f, indent=4)
 

--- a/tests/test_custom_memory.py
+++ b/tests/test_custom_memory.py
@@ -1,0 +1,35 @@
+import json
+import models.custom_memory as custom_memory
+
+
+def test_save_context_respects_limit_list(monkeypatch, tmp_path):
+    mem_file = tmp_path / "memory.json"
+    memory = custom_memory.CustomMemory(memory_file=str(mem_file))
+    monkeypatch.setattr(custom_memory, "load_neocortex_config", lambda: {"memory_limit": 3})
+
+    for i in range(5):
+        memory.save_context(f"u{i}", f"b{i}")
+
+    with open(mem_file) as f:
+        data = json.load(f)
+
+    assert len(data) == 3
+    assert [entry["user"] for entry in data] == ["u2", "u3", "u4"]
+
+
+def test_save_context_respects_limit_dict(monkeypatch, tmp_path):
+    mem_file = tmp_path / "memory.json"
+    mem_file.write_text(json.dumps({"conversation_history": []}))
+    memory = custom_memory.CustomMemory(memory_file=str(mem_file))
+    monkeypatch.setattr(custom_memory, "load_neocortex_config", lambda: {"memory_limit": 2})
+
+    for i in range(4):
+        memory.save_context(f"user{i}", f"bot{i}")
+
+    with open(mem_file) as f:
+        data = json.load(f)
+
+    assert list(data)
+    history = data["conversation_history"]
+    assert len(history) == 2
+    assert [msg["user"] for msg in history] == ["user2", "user3"]


### PR DESCRIPTION
## Summary
- enforce memory limit when saving conversation history
- add unit tests for CustomMemory trimming logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685667c08e18832eac5a3cba6dbd06df