### PR TITLE
Add feedback suggestion loop

### DIFF
--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -63,3 +63,12 @@ def test_execute_command_scan(monkeypatch, tmp_path):
         assert str(port) in output
     finally:
         server.close()
+
+
+def test_execute_command_invokes_feedback(monkeypatch, tmp_path):
+    monkeypatch.setattr(event_logger, "EVENT_LOG_FILE", str(tmp_path / "events.json"))
+    flag = {"called": False}
+    monkeypatch.setattr(command_executor, "_push_feedback", lambda: flag.__setitem__("called", True))
+    monkeypatch.setattr(command_executor, "memory", types.SimpleNamespace(save_context=lambda *a, **k: None))
+    command_executor.execute_command("echo hi")
+    assert flag["called"]

--- a/tests/test_feedback_loop.py
+++ b/tests/test_feedback_loop.py
@@ -1,0 +1,13 @@
+import modules.feedback_loop as feedback_loop
+
+def test_generate_suggestions(monkeypatch):
+    events = [
+        {"type": "command_error", "details": {}},
+        {"type": "command_error", "details": {}},
+        {"type": "scan", "details": {"ports": [80]}},
+    ]
+    monkeypatch.setattr(feedback_loop.event_logger, "load_events", lambda: events)
+    suggestions = feedback_loop.generate_suggestions(threshold=2)
+    assert any("command_error" in s for s in suggestions)
+    assert any("HTTP" in s for s in suggestions)
+


### PR DESCRIPTION
## Summary
- generate tactical suggestions from event logs
- push suggestions after each command execution
- test that feedback loop triggers correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685667c3b304832eb2019179f90a7fbf