### PR TITLE
Add pluggable guidance manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ blizz = "blizz_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["modules", "config", "models"]
+packages = ["modules", "config", "models", "guidance"]
 py_modules = ["blizz_cli", "blizz_gui", "main"]

--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -142,9 +142,9 @@ class ChatSession:
             command = user_text[1:].strip()
             response = execute_command(command)
             try:
-                from modules.cli_guidance import synthesize_guidance
+                from guidance import manager as guidance_manager
 
-                hint = synthesize_guidance(command, response)
+                hint = guidance_manager.generate(command, response)
                 if hint:
                     guidance_api.push(hint)
             except Exception:

--- a/src/guidance/__init__.py
+++ b/src/guidance/__init__.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List
+
+
+class GuidancePlugin:
+    """Base class for guidance plugins."""
+
+    def handle(self, command: str, output: str) -> str | None:
+        raise NotImplementedError
+
+
+class GuidanceManager:
+    """Dispatch command output to registered guidance plugins."""
+
+    def __init__(self) -> None:
+        self.plugins: List[GuidancePlugin] = []
+
+    def register(self, plugin: GuidancePlugin) -> None:
+        self.plugins.append(plugin)
+
+    def load_builtin(self) -> None:
+        """Register built-in plugins."""
+        from . import scan, recon, exploit
+
+        self.register(scan.ScanPlugin())
+        self.register(recon.ReconPlugin())
+        self.register(exploit.ExploitPlugin())
+
+    def generate(self, command: str, output: str) -> str:
+        for plugin in self.plugins:
+            try:
+                hint = plugin.handle(command, output)
+            except Exception:
+                hint = None
+            if hint:
+                return hint
+
+        first_line = output.strip().splitlines()[0] if output.strip() else ""
+        if first_line:
+            return f"Command output: {first_line}"
+        return ""
+
+
+manager = GuidanceManager()
+manager.load_builtin()
+
+__all__ = ["GuidancePlugin", "GuidanceManager", "manager"]

--- a/src/guidance/exploit.py
+++ b/src/guidance/exploit.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from . import GuidancePlugin
+
+
+class ExploitPlugin(GuidancePlugin):
+    """Placeholder plugin for exploitation commands."""
+
+    def handle(self, command: str, output: str) -> str | None:  # noqa: D401
+        if command.split()[0] == "exploit":
+            return "Review exploit output carefully."
+        return None

--- a/src/guidance/recon.py
+++ b/src/guidance/recon.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import re
+
+from . import GuidancePlugin
+
+
+class ReconPlugin(GuidancePlugin):
+    """Hints for reconnaissance tools like Sn1per."""
+
+    def handle(self, command: str, output: str) -> str | None:
+        if command.split()[0] != "sniper":
+            return None
+        match = re.search(r"(scan_logs/\S+\.json)", output)
+        if match:
+            return f"Sn1per results saved to {match.group(1)}"
+        return None

--- a/src/guidance/scan.py
+++ b/src/guidance/scan.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+
+from modules.port_scanner import recon_suggestions_str
+from . import GuidancePlugin
+
+
+class ScanPlugin(GuidancePlugin):
+    """Provide guidance for scan command output."""
+
+    _port_regex = re.compile(r"ports? on .*?:\s*([0-9 ,]+)")
+
+    def _parse_ports(self, output: str) -> list[int]:
+        match = self._port_regex.search(output)
+        if not match:
+            return []
+        ports: list[int] = []
+        for p in re.findall(r"\d+", match.group(1)):
+            try:
+                port = int(p)
+                if 0 < port <= 65535:
+                    ports.append(port)
+            except ValueError:
+                continue
+        return ports
+
+    def handle(self, command: str, output: str) -> str | None:  # noqa: D401
+        """Handle scan command."""
+        if command.split()[0] != "scan":
+            return None
+        ports = self._parse_ports(output)
+        if ports:
+            tips = recon_suggestions_str(ports)
+            return f"Open ports found: {', '.join(map(str, ports))}\n{tips}"
+        if "No open ports" in output:
+            return "Scan finished. No open ports detected."
+        return None

--- a/src/modules/cli_guidance.py
+++ b/src/modules/cli_guidance.py
@@ -1,40 +1,10 @@
-import re
-from modules.port_scanner import recon_suggestions_str, SERVICE_TIPS
+from __future__ import annotations
 
+"""Compatibility layer for CLI guidance."""
 
-def _parse_scan_output(output: str) -> list[int]:
-    match = re.search(r"ports? on .*?:\s*([0-9 ,]+)", output)
-    if not match:
-        return []
-    ports: list[int] = []
-    for p in re.findall(r"\d+", match.group(1)):
-        try:
-            port = int(p)
-            if 0 < port <= 65535:
-                ports.append(port)
-        except ValueError:
-            continue
-    return ports
+from guidance import manager
 
 
 def synthesize_guidance(command: str, output: str) -> str:
-    """Create a short hint for the given CLI command output."""
-    cmd = command.split()[0] if command else ""
-
-    if cmd == "scan":
-        ports = _parse_scan_output(output)
-        if ports:
-            tips = recon_suggestions_str(ports)
-            return f"Open ports found: {', '.join(map(str, ports))}\n{tips}"
-        return "Scan finished. No open ports detected."
-
-    if cmd == "sniper":
-        match = re.search(r"(scan_logs/\S+\.json)", output)
-        if match:
-            return f"Sn1per results saved to {match.group(1)}"
-
-    # Generic fallback: show first line of output
-    first_line = output.strip().splitlines()[0] if output.strip() else ""
-    if first_line:
-        return f"Command output: {first_line}"
-    return ""
+    """Return guidance by delegating to the shared manager."""
+    return manager.generate(command, output)

--- a/tests/test_guidance_manager.py
+++ b/tests/test_guidance_manager.py
@@ -1,0 +1,14 @@
+from guidance import manager
+
+
+def test_scan_guidance():
+    output = "Open ports on localhost: 22, 80"
+    hint = manager.generate("scan localhost", output)
+    assert "Open ports found" in hint
+    assert "22" in hint and "80" in hint
+
+
+def test_recon_guidance():
+    out = "results saved to scan_logs/test.json"
+    hint = manager.generate("sniper 1.1.1.1", out)
+    assert "scan_logs/test.json" in hint


### PR DESCRIPTION
## Summary
- introduce a new `guidance` package with plugin-based hints
- implement `GuidanceManager` and builtin plugins for scan/recon/exploit
- refactor CLI guidance to delegate to the new manager
- show plugin tips in the GUI through `guidance_api`
- include tests for the manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685667c23fcc832e876499cad2aa65ab