### PR TITLE
Add self-awareness feature listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Several files control various aspects of the system:
 
 - `src/config/neocortex.json` – main configuration for the bot (model selection, memory limits, greeting behaviour, etc.). Set `"use_emoji": true` to append a friendly emoji to every reply.
 - `src/config/interface_config.json` – settings for the terminal interface such as the banner text and welcome message.
+- `src/config/features.json` – list of built-in capabilities used by `self_awareness.py`.
 - `src/models/memory.json` – raw conversation history saved across sessions.
 - `src/models/processed_memory.json` – structured data produced by the memory processor.
 - `src/models/bot_mission.json` – mission statement injected into prompts.
@@ -134,4 +135,5 @@ New modules under `src/modules` provide self-monitoring features:
 - `behavior_alignment.py` checks recent behavior against the configured `system_goal`.
 - `feedback_loop.py` analyzes the event log for repeated errors.
 - `documentation_generator.py` can regenerate this README with basic details from the current configuration.
+- `self_awareness.py` lists available features from `src/config/features.json`.
 

--- a/src/config/features.json
+++ b/src/config/features.json
@@ -1,0 +1,10 @@
+{
+    "features": [
+        "Whitelisted command execution",
+        "Port scanning via threader, nmap or async methods",
+        "Session event logging",
+        "Contextual memory retrieval for responses",
+        "Module loading and self-improvement",
+        "Simple GUI and CLI interfaces"
+    ]
+}

--- a/src/modules/chat_handler.py
+++ b/src/modules/chat_handler.py
@@ -25,14 +25,25 @@ greetings = [
 
 def generate_contextual_response(user_input: str) -> str | None:
     """Return a reply that references recent command outputs."""
+    lower = user_input.lower()
+
+    # Self-awareness shortcut
+    if any(phrase in lower for phrase in (
+        "what are your features",
+        "what can you do",
+        "list your capabilities",
+        "your features",
+        "your capabilities",
+    )):
+        from modules.self_awareness import describe_features
+        return describe_features()
+
     config = load_neocortex_config()
     recent_limit = config.get("memory_retrieval", {}).get("recent_limit", 5)
 
     history = context.get_history(recent_limit)
     if not history:
         return None
-
-    lower = user_input.lower()
 
     for cmd, out, _ts in reversed(history):
         if not cmd or not out:

--- a/src/modules/self_awareness.py
+++ b/src/modules/self_awareness.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+FEATURES_FILE = os.path.join(os.path.dirname(__file__), "../config/features.json")
+
+
+def _load_features():
+    """Load feature list from ``FEATURES_FILE``."""
+    if os.path.exists(FEATURES_FILE):
+        try:
+            with open(FEATURES_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return data.get("features", [])
+        except Exception:
+            return []
+    return []
+
+
+def load_features():
+    """Public helper to return features from the JSON file."""
+    return _load_features()
+
+
+def describe_features() -> str:
+    """Return a formatted feature list."""
+    feats = load_features()
+    if not feats:
+        return "No feature data available."
+    return "\n".join(f"- {f}" for f in feats)

--- a/tests/test_self_awareness.py
+++ b/tests/test_self_awareness.py
@@ -1,0 +1,27 @@
+import json
+import types
+
+import modules.self_awareness as self_awareness
+import modules.chat_handler as chat_handler
+
+
+def test_load_features(tmp_path, monkeypatch):
+    f = tmp_path / "features.json"
+    f.write_text(json.dumps({"features": ["a", "b"]}))
+    monkeypatch.setattr(self_awareness, "FEATURES_FILE", str(f))
+    feats = self_awareness.load_features()
+    assert feats == ["a", "b"]
+    out = self_awareness.describe_features()
+    assert "- a" in out and "- b" in out
+
+
+def test_contextual_response_features(monkeypatch, tmp_path):
+    f = tmp_path / "features.json"
+    f.write_text(json.dumps({"features": ["exec", "scan"]}))
+    monkeypatch.setattr(self_awareness, "FEATURES_FILE", str(f))
+    monkeypatch.setattr(chat_handler, "load_neocortex_config", lambda: {"memory_retrieval": {"recent_limit": 5}})
+    monkeypatch.setattr(chat_handler.context, "get_history", lambda limit: [])
+    monkeypatch.setattr(chat_handler, "retrieve_processed_memory", lambda: {"conversation_history": []})
+
+    resp = chat_handler.generate_contextual_response("What can you do?")
+    assert "exec" in resp and "scan" in resp


### PR DESCRIPTION
## Summary
- add `features.json` and a `self_awareness` module
- allow `chat_handler` to answer feature queries without LLM
- test loading features and contextual response
- document the new configuration file and module in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685704724704832e98c2bab33774fda5