### PR TITLE
Add memory summarizer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ located under `src/models/`:
   history along with recent events.
 - `event_log.json` records command executions and system events. Each entry
   includes a timestamp, type and details object.
+- `memory_store.db` stores summarized messages and their vector embeddings for
+  semantic search.
 
 These files are rewritten as the bot runs and are safe to delete if you want to
 start fresh.

--- a/src/modules/embedding_utils.py
+++ b/src/modules/embedding_utils.py
@@ -1,0 +1,19 @@
+import string
+from typing import List
+
+
+def embed_text(text: str) -> List[float]:
+    """Return a vector embedding for the given text."""
+    try:
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer("all-MiniLM-L6-v2")
+        return model.encode(text).tolist()
+    except Exception:
+        # Fallback: simple letter frequency vector
+        counts = [0] * 26
+        for ch in text.lower():
+            if ch in string.ascii_lowercase:
+                counts[ord(ch) - 97] += 1
+        total = sum(counts) or 1
+        return [c / total for c in counts]

--- a/src/modules/memory_db.py
+++ b/src/modules/memory_db.py
@@ -1,0 +1,93 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List
+
+_DB_PATH = Path(__file__).resolve().parent.parent / "models" / "memory_store.db"
+_connection: sqlite3.Connection | None = None
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _connection
+    if _connection is None:
+        _connection = sqlite3.connect(_DB_PATH)
+        _connection.execute(
+            """CREATE TABLE IF NOT EXISTS memory (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            timestamp TEXT,
+            raw_input TEXT,
+            summary TEXT,
+            embedding TEXT,
+            tags TEXT
+        )"""
+        )
+        _connection.commit()
+    return _connection
+
+
+def init_db(db_path: str | None = None) -> None:
+    """Initialise the database (for testing or custom location)."""
+    global _connection, _DB_PATH
+    if db_path:
+        _DB_PATH = Path(db_path)
+        _connection = None
+    _get_conn()
+
+
+def add_entry(
+    user_id: str,
+    timestamp: str,
+    raw_input: str,
+    summary: str,
+    embedding: List[float],
+    tags: List[str] | None = None,
+) -> None:
+    conn = _get_conn()
+    conn.execute(
+        "INSERT INTO memory (user_id, timestamp, raw_input, summary, embedding, tags) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            user_id,
+            timestamp,
+            raw_input,
+            summary,
+            json.dumps(embedding),
+            json.dumps(tags or []),
+        ),
+    )
+    conn.commit()
+
+
+def _all_entries() -> List[Dict[str, Any]]:
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT user_id, timestamp, raw_input, summary, embedding, tags FROM memory"
+    )
+    entries = []
+    for row in cur.fetchall():
+        entries.append(
+            {
+                "user_id": row[0],
+                "timestamp": row[1],
+                "raw_input": row[2],
+                "summary": row[3],
+                "embedding": json.loads(row[4]),
+                "tags": json.loads(row[5]),
+            }
+        )
+    return entries
+
+
+def search(query_embedding: List[float], k: int = 5) -> List[Dict[str, Any]]:
+    """Return up to ``k`` entries sorted by dot-product similarity."""
+    entries = _all_entries()
+    if not entries:
+        return []
+
+    def score(entry: Dict[str, Any]) -> float:
+        emb = entry["embedding"]
+        n = min(len(query_embedding), len(emb))
+        return sum(query_embedding[i] * emb[i] for i in range(n))
+
+    return sorted(entries, key=score, reverse=True)[:k]
+

--- a/src/modules/summarizer.py
+++ b/src/modules/summarizer.py
@@ -1,8 +1,40 @@
-from . import chat_db
+from datetime import datetime
+from typing import Iterable, List
+
+from . import chat_db, memory_db
+from .embedding_utils import embed_text
 
 
-def summarize_messages(chat_id: int, messages) -> None:
-    """Create a naive summary of the provided messages and store it."""
+def summarize_text(text: str, max_length: int = 100, min_length: int = 30) -> str:
+    """Summarize ``text`` using transformers if available, else a simple truncation."""
+    try:
+        from transformers import pipeline
+
+        summarizer = pipeline("summarization", model="facebook/bart-large-cnn")
+        result = summarizer(text, max_length=max_length, min_length=min_length, do_sample=False)
+        return result[0]["summary_text"]
+    except Exception:
+        return text[:max_length]
+
+
+def summarize_messages(chat_id: int, messages: Iterable[tuple[str, str]]) -> None:
+    """Summarize messages for a chat and store the result."""
     text = " ".join(m[1] for m in messages)
-    summary = text[:200]
+    summary = summarize_text(text)
     chat_db.record_summary(chat_id, summary)
+
+
+def summarize_and_store(user_id: str, raw_input: str, tags: List[str] | None = None) -> None:
+    """Summarize ``raw_input`` and store it with an embedding for later retrieval."""
+    summary = summarize_text(raw_input)
+    embedding = embed_text(summary)
+    timestamp = datetime.utcnow().isoformat() + "Z"
+    memory_db.add_entry(user_id, timestamp, raw_input, summary, embedding, tags or [])
+
+
+def retrieve_relevant(query: str, k: int = 5) -> List[str]:
+    """Retrieve summaries most relevant to ``query``."""
+    vec = embed_text(query)
+    results = memory_db.search(vec, k)
+    return [r["summary"] for r in results]
+

--- a/tests/test_memory_db.py
+++ b/tests/test_memory_db.py
@@ -1,0 +1,10 @@
+import modules.memory_db as memory_db
+
+
+def test_add_and_search(tmp_path):
+    db_file = tmp_path / "mem.db"
+    memory_db.init_db(str(db_file))
+    memory_db.add_entry("u1", "t1", "raw1", "sum1", [1.0, 0.0], [])
+    memory_db.add_entry("u1", "t2", "raw2", "sum2", [0.0, 1.0], [])
+    results = memory_db.search([1.0, 0.0], k=1)
+    assert results and results[0]["summary"] == "sum1"

--- a/tests/test_summarizer_module.py
+++ b/tests/test_summarizer_module.py
@@ -1,0 +1,8 @@
+import modules.summarizer as summarizer
+
+
+def test_summarize_text_fallback(monkeypatch):
+    # Force import error for transformers
+    monkeypatch.setitem(__import__('sys').modules, 'transformers', None)
+    text = 'hello world'
+    assert summarizer.summarize_text(text, max_length=20) == text


### PR DESCRIPTION
## Summary
- implement lightweight embedding and search database
- enhance summarizer with optional Transformers support
- store summarized messages with embeddings for retrieval
- document new memory_store.db file
- test embedding database and summarizer fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659c93abb8832eb85938328497375a