### PR TITLE
Implement structured reply handling

### DIFF
--- a/tests/test_chat_loop.py
+++ b/tests/test_chat_loop.py
@@ -1,0 +1,24 @@
+import builtins
+import types
+import modules.chat_handler as chat_handler
+
+
+def test_chat_loop_prints_logic(monkeypatch, capsys):
+    inputs = iter(["hi", "exit"])
+    monkeypatch.setattr(builtins, "input", lambda *_: next(inputs))
+    monkeypatch.setattr(chat_handler, "generate_contextual_response", lambda *_: None)
+    monkeypatch.setattr(chat_handler, "process_memory", lambda *a, **k: None)
+    monkeypatch.setattr(chat_handler.memory_cache, "flush", lambda: None)
+    monkeypatch.setattr(chat_handler.event_logger, "log_event", lambda *a, **k: None)
+
+    def fake_handle(user_input):
+        return {"final_response": "ok", "thought_process": "tp", "classifications": "c", "logic_notes": "ln"}
+
+    monkeypatch.setattr(chat_handler, "handle_user_input", fake_handle)
+
+    chat_handler.chat_loop()
+    out = capsys.readouterr().out
+    assert "[NEURAL-BOT] >> ok" in out
+    assert "thought_process: tp" in out
+    assert "classifications: c" in out
+    assert "logic_notes: ln" in out

--- a/tests/test_structured_chat.py
+++ b/tests/test_structured_chat.py
@@ -1,0 +1,23 @@
+import types
+import modules.chat_handler as chat_handler
+
+
+def test_handle_user_input_parses_json(monkeypatch):
+    monkeypatch.setattr(chat_handler, "load_neocortex_config", lambda: {})
+
+    class FakeModel:
+        def invoke(self, prompt):
+            return types.SimpleNamespace(content='{"final_response": "hi", "thought_process": "tp"}')
+
+    monkeypatch.setattr(chat_handler, "main_bot", FakeModel())
+    monkeypatch.setattr(chat_handler, "retrieve_processed_memory", lambda: {"conversation_history": []})
+    monkeypatch.setattr(chat_handler, "neuron_advice", lambda *a, **k: "")
+    monkeypatch.setattr(chat_handler, "memory", types.SimpleNamespace(save_context=lambda *a, **k: None))
+    monkeypatch.setattr(chat_handler.event_logger, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(chat_handler.memory_cache, "add_message", lambda *a, **k: None)
+    monkeypatch.setattr(chat_handler.summarizer, "summarize_and_store", lambda *a, **k: None)
+
+    result = chat_handler.handle_user_input("hello")
+    assert result["final_response"] == "hi"
+    assert result["thought_process"] == "tp"
+

--- a/tests/test_use_emoji.py
+++ b/tests/test_use_emoji.py
@@ -17,5 +17,5 @@ def test_handle_user_input_appends_emoji(monkeypatch):
     monkeypatch.setattr(chat_handler.event_logger, "log_event", lambda *a, **k: None)
 
     result = chat_handler.handle_user_input("hi")
-    assert "hello" in result
-    assert "😊" in result
+    assert isinstance(result, dict)
+    assert result["final_response"] == "hello 😊"


### PR DESCRIPTION
## Summary
- introduce JSON parsing for bot replies in `chat_handler`
- propagate structured responses to the GUI and CLI
- expose reasoning text in `chat_loop`
- update GUI to display structured reasoning
- adjust tests and add new coverage for structured replies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865dc03c5f8832e9c450d9f28406f3c