### PR TITLE
Improve chat tab layout

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -26,22 +26,34 @@ class ChatSession:
 
         opts = gui.common_opts
 
-        # ----- Chat area -----
+        # ----- Chat display -----
         chat_frame = tk.Frame(self.frame, bg="#1e1e1e")
-        chat_frame.pack(fill="both", expand=True)
+        chat_frame.pack(
+            side="top",
+            fill="both",
+            expand=True,
+            padx=10,
+            pady=(5, 0),
+        )
 
-        self.chat_log = ScrolledText(chat_frame, state="disabled", **opts)
-        self.chat_log.pack(padx=10, pady=5, fill="both", expand=True)
+        chat_opts = {
+            **opts,
+            "fg": "#ffffff",
+            "bg": "#000000",
+        }
+        self.chat_log = ScrolledText(chat_frame, state="disabled", **chat_opts)
+        self.chat_log.pack(fill="both", expand=True)
 
-        input_wrap = tk.Frame(chat_frame, bg="#1e1e1e")
-        input_wrap.pack(fill="x", padx=10, pady=(0, 5))
+        # ----- Input field -----
+        input_frame = tk.Frame(self.frame, bg="#1e1e1e")
+        input_frame.pack(side="top", fill="x", padx=10, pady=5)
 
-        self.input_entry = ScrolledText(input_wrap, height=3, **opts)
+        self.input_entry = ScrolledText(input_frame, height=3, **opts)
         self.input_entry.configure(insertbackground="#00ffcc")
         self.input_entry.pack(side="left", fill="both", expand=True)
 
         send_button = tk.Button(
-            input_wrap,
+            input_frame,
             text="Send",
             command=self.handle_input,
             bg="#1e1e1e",
@@ -49,11 +61,15 @@ class ChatSession:
         )
         send_button.pack(side="left", padx=(5, 0))
 
-        # ----- Logic area -----
+        # ----- Logic output -----
         logic_frame = tk.Frame(self.frame, bg="#002244")
-        logic_frame.pack(fill="both", expand=True, padx=10, pady=(0, 5))
+        logic_frame.pack(side="top", fill="both", expand=True, padx=10, pady=(0, 5))
 
-        logic_opts = {"font": ("Courier New", 11), "fg": "#dddddd", "bg": "#002244"}
+        logic_opts = {
+            "font": ("Courier New", 11),
+            "fg": "#00ffff",
+            "bg": "#002244",
+        }
         self.logic_box = ScrolledText(logic_frame, height=10, state="disabled", **logic_opts)
         self.logic_box.pack(fill="both", expand=True)
 
@@ -66,9 +82,11 @@ class ChatSession:
             bg="#1e1e1e",
             fg="#00ffcc",
         )
-        close_btn.pack(padx=10, pady=(0, 5))
+        close_btn.pack(side="top", fill="x", padx=10, pady=(0, 5))
 
+        # Load any previous conversation history for this session
         self.load_history()
+
 
     def cleanup(self) -> None:
         if self.file_path.exists():


### PR DESCRIPTION
## Summary
- tidy up chat session layout using pack
- keep conversation at the top, input box in the middle, and logic output at the bottom
- fix indentation for chat_frame to avoid layout issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e7da7a4c832e8a8ad40f73443345