### PR TITLE
Update GUI dashboard refresh

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -263,6 +263,8 @@ class ChatSession:
     def _handle_response(self, chat_txt: str, logic_txt: str) -> None:
         self.update_displays(f"Bot: {chat_txt}", logic_txt)
         self.append_history("bot", chat_txt)
+        if hasattr(self.gui, "dashboard"):
+            dashboard.refresh_dashboard()
 
 
 class BlizzGUI:

--- a/tests/test_blizz_gui_dashboard_refresh.py
+++ b/tests/test_blizz_gui_dashboard_refresh.py
@@ -1,0 +1,24 @@
+import types
+
+import blizz_gui
+from modules import dashboard
+
+
+def test_handle_response_triggers_dashboard_refresh(monkeypatch):
+    called = {"refreshed": False}
+
+    def fake_refresh():
+        called["refreshed"] = True
+
+    monkeypatch.setattr(dashboard, "refresh_dashboard", fake_refresh)
+
+    dummy_gui = types.SimpleNamespace(dashboard=object())
+    session = types.SimpleNamespace(
+        update_displays=lambda *a, **k: None,
+        append_history=lambda *a, **k: None,
+        gui=dummy_gui,
+    )
+
+    blizz_gui.ChatSession._handle_response(session, "hi", "logic")
+
+    assert called["refreshed"]


### PR DESCRIPTION
## Summary
- refresh dashboard after bot responses
- add regression test for dashboard refresh logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661990f018832ea40ec3c9c3328bf7