### PR TITLE
Fix logic extraction

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -147,6 +147,14 @@ class ChatSession:
             chat, logic = response.split("[[THINK]]", 1)
             return chat.strip(), logic.strip()
 
+        # Fallback for "Bot: Bot:" style thinking. If present treat everything
+        # from the second "Bot:" onward as raw logic meant for the bottom pane.
+        botbot = re.search(r"(Bot:\s*Bot:.*)", response, re.DOTALL)
+        if botbot:
+            chat = response[: botbot.start()].strip()
+            logic = botbot.group(1).strip()
+            return chat, logic
+
         suggestion = ""
         guidance = ""
         cleaned = response
@@ -199,10 +207,11 @@ class ChatSession:
         return self.parse_response(str(response))
 
     def update_displays(self, chat_text: str, logic_text: str) -> None:
-        """Insert messages into the chat pane and raw logic into the bottom pane."""
-        chat_msg = {"type": "assistant_response", "content": chat_text}
-        self.messages.append(chat_msg)
-        self.render_message(chat_msg)
+        """Insert chat text and logic output into their respective panes."""
+        if chat_text:
+            chat_msg = {"type": "assistant_response", "content": chat_text}
+            self.messages.append(chat_msg)
+            self.render_message(chat_msg)
 
         # Logic text should not be treated as a persistent message. It is
         # appended only to the logic box for debugging purposes.
@@ -264,7 +273,9 @@ class ChatSession:
         self.gui.root.after(0, lambda: self._handle_response(chat_txt, logic_txt))
 
     def _handle_response(self, chat_txt: str, logic_txt: str) -> None:
-        self.update_displays(f"Bot: {chat_txt}", logic_txt)
+        # update_displays already prefixes bot messages, so pass the raw text
+        # to avoid duplicating the label.
+        self.update_displays(chat_txt, logic_txt)
         self.append_history("bot", chat_txt)
         if hasattr(self.gui, "dashboard"):
             dashboard.refresh_dashboard()

--- a/tests/test_chat_session_display.py
+++ b/tests/test_chat_session_display.py
@@ -1,6 +1,7 @@
 import types
 from blizz_gui import ChatSession
 
+
 class DummyWidget:
     def __init__(self):
         self.content = ""
@@ -28,7 +29,7 @@ def make_session():
 def test_think_delimiter_logic_bottom_only():
     session = make_session()
     chat, logic = session.parse_response("hello[[THINK]]logic goes here")
-    session.update_displays(f"Bot: {chat}", logic)
+    session.update_displays(chat, logic)
     assert "hello" in session.chat_log.content
     assert "logic goes here" in session.logic_box.content
     assert "logic goes here" not in session.chat_log.content
@@ -37,12 +38,33 @@ def test_think_delimiter_logic_bottom_only():
 
 def test_structured_keys_logic_bottom_only():
     session = make_session()
-    chat, logic = session.structure_response({
-        "user_facing_response": "hey",
-        "bot_logic_output": "some reasoning",
-    })
-    session.update_displays(f"Bot: {chat}", logic)
+    chat, logic = session.structure_response(
+        {
+            "user_facing_response": "hey",
+            "bot_logic_output": "some reasoning",
+        }
+    )
+    session.update_displays(chat, logic)
     assert "Bot: hey" in session.chat_log.content
     assert "some reasoning" in session.logic_box.content
     assert "some reasoning" not in session.chat_log.content
     assert len(session.messages) == 1
+
+
+def test_botbot_logic_extracted():
+    session = make_session()
+    chat, logic = session.parse_response("Hi there Bot: Bot: internal")
+    session.update_displays(chat, logic)
+    assert "Hi there" in session.chat_log.content
+    assert "Bot: Bot: internal" in session.logic_box.content
+    assert "Bot: Bot: internal" not in session.chat_log.content
+    assert len(session.messages) == 1
+
+
+def test_logic_only_skips_chat():
+    session = make_session()
+    chat, logic = session.parse_response("Bot: Bot: full instruction")
+    session.update_displays(chat, logic)
+    assert session.chat_log.content == ""
+    assert "Bot: Bot: full instruction" in session.logic_box.content
+    assert len(session.messages) == 0


### PR DESCRIPTION
## Summary
- detect legacy `Bot: Bot:` blocks when parsing responses
- stop duplicating bot label in GUI
- skip empty bot messages so only real responses show in the chat
- test GUI session display for old delimiter and empty chat case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663892b2d0832e8bfa50bc6ba623f6