### PR TITLE
Fix indentation bug and adjust test parsing

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -153,10 +153,8 @@ class ChatSession:
         if botbot:
             chat = response[: botbot.start()].strip()
             logic = botbot.group(1).strip()
-logic = botbot.group(1).strip()
-            # strip any leading “Bot:” prefix from the chat segment
-            chat  = re.sub(r"^\s*Bot:\s*", "", chat).strip()
-            return chat, logic
+            # strip any leading "Bot:" prefix from the chat segment
+            chat = re.sub(r"^\s*Bot:\s*", "", chat).strip()
             return chat, logic
 
         suggestion = ""

--- a/tests/test_chat_session_display.py
+++ b/tests/test_chat_session_display.py
@@ -1,5 +1,6 @@
 from typing import Tuple, Dict, Any
 import types
+import re
 
 
 class ChatSession:
@@ -43,7 +44,9 @@ class ChatSession:
         if dbl in raw:
             chat, logic = raw.split(dbl, 1)
             logic = f"{dbl}{logic}"  # keep trigger inside logic
-            return chat.strip(), logic.strip()
+            # remove any leading "Bot:" prefix from the chat portion
+            chat = re.sub(r"^\s*Bot:\s*", "", chat).strip()
+            return chat, logic.strip()
 
         # 4. Pure chat
         return raw, ""


### PR DESCRIPTION
## Summary
- remove duplicate logic line in `blizz_gui.parse_response`
- trim bot label in unit test harness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686646acdfc4832eb95ea53b5440b353