### PR TITLE
Improve GUI instruction routing and tests

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -17,6 +17,10 @@ from modules import dashboard
 class ChatSession:
     """Representation of a single chat session."""
 
+    _INSTRUCTION_PREFIXES = (
+        "Bot: The main bot should respond",
+    )
+
     def __init__(self, gui: "BlizzGUI", parent: ttk.Notebook, session_id: int) -> None:
         self.gui = gui
         self.session_id = session_id
@@ -146,6 +150,12 @@ class ChatSession:
         if "[[THINK]]" in response:
             chat, logic = response.split("[[THINK]]", 1)
             return chat.strip(), logic.strip()
+
+        # Entire response is leaked instructions
+        stripped = response.strip()
+        for pref in self._INSTRUCTION_PREFIXES:
+            if stripped.startswith(pref):
+                return "", stripped
 
         # Fallback for "Bot: Bot:" style thinking. If present treat everything
         # from the second "Bot:" onward as raw logic meant for the bottom pane.


### PR DESCRIPTION
## Summary
- route leaked "Bot: The main bot should respond" instructions to the logic pane
- test the real `ChatSession.parse_response`
- verify leaked instruction prefix is captured in logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664ad01f1c832e988b1d622bf1993b