### PR TITLE
Improve instruction prefix parsing

### DIFF
--- a/src/blizz_gui.py
+++ b/src/blizz_gui.py
@@ -18,7 +18,7 @@ class ChatSession:
     """Representation of a single chat session."""
 
     _INSTRUCTION_PREFIXES = (
-        "Bot: The main bot should respond",
+        "Bot: The main bot should",
     )
 
     def __init__(self, gui: "BlizzGUI", parent: ttk.Notebook, session_id: int) -> None:
@@ -153,8 +153,9 @@ class ChatSession:
 
         # Entire response is leaked instructions
         stripped = response.strip()
+        stripped_lower = stripped.lower()
         for pref in self._INSTRUCTION_PREFIXES:
-            if stripped.startswith(pref):
+            if stripped_lower.startswith(pref.lower()):
                 return "", stripped
 
         # Fallback for "Bot: Bot:" style thinking. If present treat everything

--- a/tests/test_chat_session_display.py
+++ b/tests/test_chat_session_display.py
@@ -88,3 +88,11 @@ def test_instruction_prefix_routed_to_logic():
     chat, logic = session.parse_response(instr)
     assert chat == ""
     assert logic == instr
+
+
+def test_instruction_prefix_extended_pattern():
+    session = make_session()
+    instr = "Bot: The main bot should address the user"
+    chat, logic = session.parse_response(instr)
+    assert chat == ""
+    assert logic == instr


### PR DESCRIPTION
## Summary
- broaden the instruction prefix to allow variations like "Bot: The main bot should"
- handle instruction prefixes case-insensitively
- add a test covering a new prefix form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866536f1c00832eb23bfd48f75e1732